### PR TITLE
Drag & Drop

### DIFF
--- a/vivarium/interface/panel_app.py
+++ b/vivarium/interface/panel_app.py
@@ -186,7 +186,7 @@ class WindowManager(Parameterized):
     start_toggle = pn.widgets.Toggle(**({"name": "Stop", "value": True} if controller.is_started()
                                         else {"name": "Start", "value": False}),align="center")
     entity_toggle = pn.widgets.ToggleGroup(name="EntityToggle", options=config_types,
-                                           align="center")
+                                           align="center", value=config_types[1:])
     update_switch = pn.widgets.Switch(name="Update plot", value=True, align="center")
     update_timestep = pn.widgets.IntSlider(name="Timestep (ms)", value=10, start=0, end=1000)
     def __init__(self, **kwargs):
@@ -244,9 +244,9 @@ class WindowManager(Parameterized):
                 sizing_mode="scale_both",scroll=True, name="test")] +
             [pn.Column(
                 self.controller.selected_entities[etype],
-                self.controller.selected_panel_configs[etype],
+                pn.panel(self.controller.selected_panel_configs[etype], name="Visualization configs"),
                 self.controller.selected_configs[etype],
-                visible=False, sizing_mode="stretch_width", scroll=True)
+                visible=True, sizing_mode="stretch_width", scroll=True)
             for etype in EntityType])
 
         p_tools = "crosshair,pan,wheel_zoom,box_zoom,reset,tap,box_select,lasso_select"


### PR DESCRIPTION
## Description
Refactored file to clean the code a little;
Added a callback to update configs when an entity is dragged in the plot;

## Related Issue (if applicable)
\-

## How to Test
Launch the server
```
python3 vivarium/simulator/grpc_server/simulator_server.py
```
Launch the Panel interface
```
panel serve vivarium/interface/panel_app.py --autoreload
```
Turn off the plot update (and the server to not produce weird movement), select the `PointDrawTool` on the side of the plot, and drag & drop an agent or an object. It should move the entity accordingly, and stays even after re-enabling the plot update.

## Screenshots (if applicable)
<!--- Provide screenshots to demonstrate the changes visually, if applicable -->
<img width="28" alt="Screenshot 2024-03-05 at 15 13 19" src="https://github.com/clement-moulin-frier/vivarium/assets/48359214/3b3a3ce7-a23e-47d8-93e6-028d222a9841"> Point Draw Tool
