### PR TITLE
Hide non-existing entities & toggle config update

### DIFF
--- a/vivarium/controllers/panel_controller.py
+++ b/vivarium/controllers/panel_controller.py
@@ -121,13 +121,13 @@ class PanelController(SimulatorController):
     def push_selected_to_config_list(self, *events):
         lg.info('push_selected_to_config_list %d', len(events))
         for e in events:
-            if isinstance(e.obj, PanelEntityConfig):
+            if isinstance(e.obj, PanelConfig):
                 stype = panel_config_to_stype[type(e.obj)]
             else:
                 stype = config_to_stype[type(e.obj)]
             selected_entities = self.selected_entities[stype.to_entity_type()].selection
             for idx in selected_entities:
-                if isinstance(e.obj, PanelEntityConfig):
+                if isinstance(e.obj, PanelConfig):
                     setattr(self.panel_configs[stype][idx], e.name, e.new)
                 else:
                     setattr(self.configs[stype][idx], e.name, e.new)

--- a/vivarium/interface/panel_app.py
+++ b/vivarium/interface/panel_app.py
@@ -36,7 +36,7 @@ class EntityManager:
                              onlychanged=True, precedence=0)
         for i, pc in enumerate(self.panel_configs):
             pc.param.watch(self.update_cds_view, pc.param_names(), onlychanged=True)
-            self.config[i].param.watch(self.e, "exists", onlychanged=True)
+            self.config[i].param.watch(self.hide_non_existing, "exists", onlychanged=False)
 
     def drag_cb(self, attr, old, new):
         for i, c in enumerate(self.config):
@@ -68,7 +68,7 @@ class EntityManager:
         n = event.name
         for attr in [n] if n != "visible" else self.panel_configs[0].param_names():
             f = [getattr(pc, attr) and pc.visible for pc in self.panel_configs]
-            self.cds_view[attr].filter.booleans = f
+            self.cds_view[attr].filter = BooleanFilter(f)
 
     def update_selected_plot(self, event):
         self.cds.selected.indices = event.new
@@ -78,10 +78,11 @@ class EntityManager:
             if not self.config[i].exists:
                 pc.visible = not event.new
 
-    def e(self, event):
+    def hide_non_existing(self, event):
         if not self.panel_simulator_config.hide_non_existing:
             return
-        self.panel_configs[event.obj.idx].visible = event.new
+        idx = self.config.index(event.obj)
+        self.panel_configs[idx].visible = event.new
 
 
     def update_selected_simulator(self):


### PR DESCRIPTION
## Description
Added two panel simulator configs, for the following additions:
- Can now toggle if non-existing entities should be hidden or not (`hide_non_existing`);
- Can now toggle if configs values visible in the panel app should refresh along with the plot update (`config_update`)

## Related Issue (if applicable)
closes #31 
closes #32 

## How to Test
Launch the server
```
python3 scripts/_server.py
```
Launch the Panel interface
```
panel serve scripts/run_interface.py --autoreload
```
- For the visibility of non-existing entities:
Select one or more agents or objects and uncheck their `exists` attribute, this should hide them in the plot.
If you uncheck `hide non existing` in the simulator configs, that should make them visible again.

- For the config update:
Check the `config update` checkbox in the simulator configs and start the server, the values in the agent configs and object configs should update in real-time.

## Screenshots (if applicable)
<!--- Provide screenshots to demonstrate the changes visually, if applicable -->
