### PR TITLE
Improve notebook controller API

### DIFF
--- a/notebooks/sessions/session_3.ipynb
+++ b/notebooks/sessions/session_3.ipynb
@@ -108,18 +108,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/jax/_src/ops/scatter.py:96: FutureWarning: scatter inputs have incompatible types: cannot safely cast value from dtype=float32 to dtype=int32 with jax_numpy_dtype_promotion='standard'. In future JAX releases this will result in an error.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "controller = NotebookController()"
    ]
@@ -133,43 +124,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Exception in thread Thread-5 (_run):\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/usr/lib/python3.10/threading.py\", line 1016, in _bootstrap_inner\n",
-      "    self.run()\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/ipykernel/ipkernel.py\", line 766, in run_closure\n",
-      "    _threading_Thread_run(self)\n",
-      "  File \"/usr/lib/python3.10/threading.py\", line 953, in run\n",
-      "    self._target(*self._args, **self._kwargs)\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py\", line 513, in _run\n",
-      "    with self.batch_set_state():\n",
-      "  File \"/usr/lib/python3.10/contextlib.py\", line 142, in __exit__\n",
-      "    next(self.gen)\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/controllers/simulator_controller.py\", line 72, in batch_set_state\n",
-      "    self.push_state(*self._event_list)\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/controllers/simulator_controller.py\", line 52, in push_state\n",
-      "    self.client.set_state(**sc._asdict())\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/simulator/grpc_server/simulator_client.py\", line 41, in set_state\n",
-      "    self.stub.SetState(state_change)\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/grpc/_channel.py\", line 1160, in __call__\n",
-      "    return _end_unary_response_blocking(state, call, False, None)\n",
-      "  File \"/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/grpc/_channel.py\", line 1003, in _end_unary_response_blocking\n",
-      "    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable\n",
-      "grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:\n",
-      "\tstatus = StatusCode.UNAVAILABLE\n",
-      "\tdetails = \"Socket closed\"\n",
-      "\tdebug_error_string = \"UNKNOWN:Error received from peer  {grpc_message:\"Socket closed\", grpc_status:14, created_time:\"2024-11-26T11:26:48.927417525+01:00\"}\"\n",
-      ">\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "controller.run()"
    ]
@@ -187,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -223,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,14 +189,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.7939733862876892 0.4993416666984558\n"
+      "0.8058567047119141 0.5096818208694458\n"
      ]
     }
    ],
@@ -250,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +221,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FPS: 34.50\n"
+      "FPS: 35.50\n"
      ]
     }
    ],
@@ -281,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -305,14 +262,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.0424196720123291 0.44503527879714966\n"
+      "0 0.4364292025566101\n"
      ]
     }
    ],
@@ -330,14 +287,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.05865830183029175 0.4533795714378357\n"
+      "0.163119375705719 0.48004770278930664\n"
      ]
     }
    ],
@@ -355,19 +312,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "ename": "AssertionError",
-     "evalue": "Please specify valid sensed entities among {'robots', 'resources', 'obstacles'}",
+     "evalue": "Please specify valid sensed entities among {'obstacles', 'robots', 'resources'}",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[43magent\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msensors\u001b[49m\u001b[43m(\u001b[49m\u001b[43msensed_entities\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mnon_existing_type\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py:149\u001b[0m, in \u001b[0;36mAgent.sensors\u001b[0;34m(self, sensed_entities)\u001b[0m\n\u001b[1;32m    146\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mleft_prox, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mright_prox\n\u001b[1;32m    147\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m sensed_entities \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    148\u001b[0m     \u001b[38;5;66;03m# transform the strings of sensed entities into ints (this fn can surely be optimized)\u001b[39;00m\n\u001b[0;32m--> 149\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mall\u001b[39m(ent_subtype \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes \u001b[38;5;28;01mfor\u001b[39;00m ent_subtype \u001b[38;5;129;01min\u001b[39;00m sensed_entities), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPlease specify valid sensed entities among \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    150\u001b[0m     sensed_entities \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_subtype_label_to_idx[label] \u001b[38;5;28;01mfor\u001b[39;00m label \u001b[38;5;129;01min\u001b[39;00m sensed_entities]\n\u001b[1;32m    151\u001b[0m     sensed_type_left, sensed_type_right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprox_sensed_ent_type\n",
-      "\u001b[0;31mAssertionError\u001b[0m: Please specify valid sensed entities among {'robots', 'resources', 'obstacles'}"
+      "Cell \u001b[0;32mIn[12], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[43magent\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msensors\u001b[49m\u001b[43m(\u001b[49m\u001b[43msensed_entities\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mnon_existing_type\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py:151\u001b[0m, in \u001b[0;36mAgent.sensors\u001b[0;34m(self, sensed_entities)\u001b[0m\n\u001b[1;32m    148\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mleft_prox, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mright_prox\n\u001b[1;32m    149\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m sensed_entities \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    150\u001b[0m     \u001b[38;5;66;03m# transform the strings of sensed entities into ints (this fn can surely be optimized)\u001b[39;00m\n\u001b[0;32m--> 151\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mall\u001b[39m(ent_subtype \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes \u001b[38;5;28;01mfor\u001b[39;00m ent_subtype \u001b[38;5;129;01min\u001b[39;00m sensed_entities), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPlease specify valid sensed entities among \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    152\u001b[0m     sensed_entities \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_subtype_label_to_idx[label] \u001b[38;5;28;01mfor\u001b[39;00m label \u001b[38;5;129;01min\u001b[39;00m sensed_entities]\n\u001b[1;32m    153\u001b[0m     sensed_type_left, sensed_type_right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprox_sensed_ent_type\n",
+      "\u001b[0;31mAssertionError\u001b[0m: Please specify valid sensed entities among {'obstacles', 'robots', 'resources'}"
      ]
     }
    ],
@@ -419,14 +376,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.5305280685424805 0\n"
+      "0 0.7445070743560791\n"
      ]
     }
    ],
@@ -447,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -508,9 +465,9 @@
       "Subtype: robots\n",
       "Idx: 0\n",
       "Exists: True\n",
-      "Position: x=63.00, y=65.96\n",
+      "Position: x=74.00, y=59.51\n",
       "\n",
-      "Sensors: Left=0.57, Right=0.68\n",
+      "Sensors: Left=0.72, Right=-0.00\n",
       "Motors: Left=0.00, Right=0.00\n",
       "\n",
       "No behaviors attached\n"
@@ -540,25 +497,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Comment : \n",
-    "\n",
-    "at the moment manually attach a routine so the agent eats resources"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for ag in controller.agents:\n",
-    "    ag.diet = [\"resources\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Comment \n",
     "\n",
     "- to make sure it works well make the robot turn on himself with following cmd "
@@ -566,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,12 +516,168 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We want to implement a mechanism where agents will eat only ressources. To do so, we have to do three things:\n",
+    "\n",
+    "- Add `resources` to the agents's diets\n",
+    "- Start the eating mechanism in the controller\n",
+    "- Start the apparition of `resources` in the environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Manipulate the diet of agents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Different subtypes of entities:\n",
+      "['obstacles', 'robots', 'resources']\n",
+      "\n",
+      "Agent eating information:\n",
+      "Current agent diet: ['resources']\n",
+      "Current agent eating range: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Different subtypes of entities:\")\n",
+    "controller.print_subtypes_list()\n",
+    "\n",
+    "print(f\"\\nAgent eating information:\")\n",
+    "print(f\"Current agent diet: {agent.diet}\")\n",
+    "print(f\"Current agent eating range: {agent.eating_range}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also get theses informations by using the print_infos() function, with `full_infos` set to True: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Entity Overview:\n",
+      "--------------------\n",
+      "Type: AGENT\n",
+      "Subtype: robots\n",
+      "Idx: 0\n",
+      "Exists: True\n",
+      "Position: x=74.03, y=56.30\n",
+      "\n",
+      "Sensors: Left=0.77, Right=0.04\n",
+      "Motors: Left=0.80, Right=0.00\n",
+      "\n",
+      "Diet: ['resources']\n",
+      "Eating range: 10\n",
+      "\n",
+      "Configuration Details:\n",
+      "  - color: #0000ff\n",
+      "  - diameter: 10.0\n",
+      "  - exists: True\n",
+      "  - friction: 0.10000000149011612\n",
+      "  - idx: 0\n",
+      "  - left_prox: 0.7707440853118896\n",
+      "  - mass_center: 1.0\n",
+      "  - mass_orientation: 0.125\n",
+      "  - max_speed: 10.0\n",
+      "  - orientation: -485.9183654785156\n",
+      "  - prox_sensed_ent_idx: [ 4 14]\n",
+      "  - prox_sensed_ent_type: [1 2]\n",
+      "  - proximity_map_dist: [  0.          82.69258881  99.6177597   87.17667389  13.75535393\n",
+      "  19.25267029  25.86472893  86.72187805  81.89463806 100.56718445\n",
+      "  29.92865944 101.04159546  92.33370972 115.61449432  57.42391205\n",
+      "  17.15402794  98.66919708  59.35287476  79.44650269  43.66890335\n",
+      " 110.7736969   77.92525482  62.45607758  76.61223602  96.63103485\n",
+      " 110.02033234  84.20428467  40.62639999  88.3372879 ]\n",
+      "  - proximity_map_theta: [  0.         487.40603638 486.29891968 485.28283691 484.81417847\n",
+      " 488.13751221 487.00082397 484.74783325 487.43701172 486.77337646\n",
+      " 488.5614624  486.86755371 483.80093384 486.61331177 488.98770142\n",
+      " 487.05633545 484.33291626 483.00845337 487.16018677 485.02035522\n",
+      " 486.97052002 484.73855591 488.51141357 486.75973511 486.68289185\n",
+      " 485.3923645  483.78356934 488.38848877 487.36938477]\n",
+      "  - proxs_cos_min: 0.0\n",
+      "  - proxs_dist_max: 60.0\n",
+      "  - right_prox: 0.04293477535247803\n",
+      "  - speed_mul: 1.0\n",
+      "  - subtype: 0\n",
+      "  - theta_mul: 1.0\n",
+      "  - wheel_diameter: 2.0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent.print_infos(full_infos=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent.diet = [\"resources\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, if the eating mechanism is started, the agents will eat the resources. If we wanted them to eat other kind of entities such as obstacles, we would have to add 'obstacles' to the diet of the agents (make sure to respect the good ortograph of the entities with the controller.print_subtypes_list() function)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Start the eating mechanism\n",
+    "\n",
+    "You can start the eating of the controller mechanism with the command in the following cell. This will make the agents eat the resources in their diet and eating range. You also have an option to only eat the resources in your proximeters range ... don't know if it is useful to tell it here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controller.start_eating_mechanism()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Start spawning of resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Can start ressources apparition, will also start eating mechanism of the server where agents can eat resources when close to them. TO do so, define an interval of steps between each apparition of a resource with the 'interval' parameter. To get a good approximation of this interval, use the get fps function to know how many steps per seconds"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -597,7 +691,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FPS: 34.00\n"
+      "FPS: 32.00\n"
      ]
     }
    ],
@@ -614,17 +708,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "new fn\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "seconds = 2\n",
     "fps = 28\n",
@@ -635,7 +721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,22 +755,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Entity 6 already removed\n",
-      "Entity 7 already removed\n",
-      "Entity 8 already removed\n",
-      "Entity 10 already removed\n",
-      "Entity 11 already removed\n",
-      "Entity 12 already removed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "controller.remove_entity_type(\"resources\")"
    ]
@@ -693,114 +766,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It will print an information message for all the non existing entities of this type we tried to remove (here, already non-existing ressources)."
+    "If the resources apparition function is still attached to the controller, it will keep spawning resources even after removing them with the precedent function. It will print an information message for all the non existing entities of this type we tried to remove (here, already non-existing ressources)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also specify in which area spheres appear through the `min_pos` and `max_pos` arguments:\n",
-    "\n",
-    "--> Not implemented yet, bug with custom positions"
+    "### Custom position of resources spawning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also control the position range where the resources will appear with the `position_range` parameter. This parameter is a list of 4 values: ((x_min, x_max), (y_min, y_max)) where x_min and x_max are the minimum and maximum x coordinates of the spawning area, and y_min and y_max are the minimum and maximum y coordinates of the spawning area. For example, to make resources appear only in the area between x=0 and x=50, and y=100 and y=200:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "inf"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "agent.time_since_last_meal"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "agent.has_eaten_since(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "inf\n"
-     ]
-    }
-   ],
-   "source": [
-    "agent.time_since_last_meal += 10\n",
-    "print(agent.time_since_last_meal)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "inf\n"
-     ]
-    }
-   ],
-   "source": [
-    "agent.time_since_last_meal += 1000\n",
-    "print(agent.time_since_last_meal)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "new fn\n"
-     ]
-    }
-   ],
-   "source": [
+    "# first remove all the resources and stop the resources apparition\n",
+    "controller.remove_entity_type(\"resources\")\n",
+    "controller.stop_resources_apparition()\n",
+    "# then, start the spawning apparition in a specific area\n",
     "controller.start_resources_apparition(interval=interval, position_range=((0, 50), (100, 200)))"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can play with this process a bit, and then stop it."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -850,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -906,7 +911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -936,17 +941,6 @@
    ],
    "source": [
     "agent.print_behaviors()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Comment \n",
-    "\n",
-    "- problem is that there are a lot of resources\n",
-    "- so agent just follows the resources and we can't really see the obstacle avoidance\n",
-    "- might need to put really few resources but not sure it will work"
    ]
   },
   {
@@ -1001,13 +995,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Make all agents spawn\n",
+    "# Make all agents spawn with the exists flag\n",
     "for ag in controller.agents:\n",
     "    ag.exists = True\n",
+    "    agent.diet = [\"resources\"]\n",
     "\n",
     "agent_0 = controller.agents[0]\n",
     "agent_1 = controller.agents[1]"

--- a/notebooks/sessions/session_3.ipynb
+++ b/notebooks/sessions/session_3.ipynb
@@ -66,6 +66,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Server and Interface Stopped\n",
       "/home/cleger/Desktop/code/vivarium/vivarium/utils\n",
       "STARTING SERVER\n"
      ]
@@ -81,29 +82,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2024-11-08 15:57:45,674][__main__][INFO] - Scene running: session_3\n",
+      "[2024-11-26 11:24:11,155][__main__][INFO] - Scene running: session_3\n",
+      "[2024-11-26 11:24:13,681][vivarium.simulator.simulator][INFO] - Simulator initialized\n",
       "\n",
       "STARTING INTERFACE\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2024-11-08 15:57:49,030][vivarium.simulator.simulator][INFO] - Simulator initialized\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-11-08 15:57:49,636 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
-      "2024-11-08 15:57:49,636 User authentication hooks NOT provided (default user enabled)\n",
-      "2024-11-08 15:57:49,638 Bokeh app running at: http://localhost:5006/run_interface\n",
-      "2024-11-08 15:57:49,638 Starting Bokeh server with process id: 26738\n",
-      "2024-11-08 15:57:51,717 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
-      "2024-11-08 15:57:53,828 WebSocket connection opened\n",
-      "2024-11-08 15:57:53,863 ServerConnection created\n"
+      "2024-11-26 11:24:15,495 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
+      "2024-11-26 11:24:15,495 User authentication hooks NOT provided (default user enabled)\n",
+      "2024-11-26 11:24:15,497 Bokeh app running at: http://localhost:5006/run_interface\n",
+      "2024-11-26 11:24:15,497 Starting Bokeh server with process id: 18344\n",
+      "2024-11-26 11:24:18,309 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
+      "2024-11-26 11:24:19,982 WebSocket connection opened\n",
+      "2024-11-26 11:24:20,008 ServerConnection created\n"
      ]
     }
    ],
@@ -113,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -138,9 +133,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception in thread Thread-5 (_run):\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/usr/lib/python3.10/threading.py\", line 1016, in _bootstrap_inner\n",
+      "    self.run()\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/ipykernel/ipkernel.py\", line 766, in run_closure\n",
+      "    _threading_Thread_run(self)\n",
+      "  File \"/usr/lib/python3.10/threading.py\", line 953, in run\n",
+      "    self._target(*self._args, **self._kwargs)\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py\", line 513, in _run\n",
+      "    with self.batch_set_state():\n",
+      "  File \"/usr/lib/python3.10/contextlib.py\", line 142, in __exit__\n",
+      "    next(self.gen)\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/controllers/simulator_controller.py\", line 72, in batch_set_state\n",
+      "    self.push_state(*self._event_list)\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/controllers/simulator_controller.py\", line 52, in push_state\n",
+      "    self.client.set_state(**sc._asdict())\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/vivarium/simulator/grpc_server/simulator_client.py\", line 41, in set_state\n",
+      "    self.stub.SetState(state_change)\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/grpc/_channel.py\", line 1160, in __call__\n",
+      "    return _end_unary_response_blocking(state, call, False, None)\n",
+      "  File \"/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/grpc/_channel.py\", line 1003, in _end_unary_response_blocking\n",
+      "    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable\n",
+      "grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:\n",
+      "\tstatus = StatusCode.UNAVAILABLE\n",
+      "\tdetails = \"Socket closed\"\n",
+      "\tdebug_error_string = \"UNKNOWN:Error received from peer  {grpc_message:\"Socket closed\", grpc_status:14, created_time:\"2024-11-26T11:26:48.927417525+01:00\"}\"\n",
+      ">\n"
+     ]
+    }
+   ],
    "source": [
     "controller.run()"
    ]
@@ -158,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -180,9 +209,9 @@
       "Subtype: robots\n",
       "Idx: 0\n",
       "Exists: True\n",
-      "Position: x=102.98, y=107.84\n",
+      "Position: x=68.65, y=71.90\n",
       "\n",
-      "Sensors: Left=0.69, Right=0.25\n",
+      "Sensors: Left=0.79, Right=0.50\n",
       "Motors: Left=0.00, Right=0.00\n",
       "\n"
      ]
@@ -194,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,14 +232,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.690665602684021 0.24877935647964478\n"
+      "0.7939733862876892 0.4993416666984558\n"
      ]
     }
    ],
@@ -221,21 +250,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "measuring the number of steps per second in the controller for 2 seconds\n"
+      "measuring the FPS (number of steps per second) in the controller during 2 seconds\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FPS: 28.50 (number of steps per second in the controller)\n"
+      "FPS: 34.50\n"
      ]
     }
    ],
@@ -252,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -276,14 +305,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.3124312162399292 0\n"
+      "0.0424196720123291 0.44503527879714966\n"
      ]
     }
    ],
@@ -308,7 +337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.7224568724632263 0\n"
+      "0.05865830183029175 0.4533795714378357\n"
      ]
     }
    ],
@@ -330,13 +359,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FPS: 27.50 (number of steps per second in the controller)\n"
-     ]
-    },
-    {
      "ename": "AssertionError",
      "evalue": "Please specify valid sensed entities among {'robots', 'resources', 'obstacles'}",
      "output_type": "error",
@@ -344,7 +366,7 @@
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
       "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[43magent\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msensors\u001b[49m\u001b[43m(\u001b[49m\u001b[43msensed_entities\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mnon_existing_type\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py:145\u001b[0m, in \u001b[0;36mAgent.sensors\u001b[0;34m(self, sensed_entities)\u001b[0m\n\u001b[1;32m    142\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mleft_prox, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mright_prox\n\u001b[1;32m    143\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m sensed_entities \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    144\u001b[0m     \u001b[38;5;66;03m# transform the strings of sensed entities into ints (this fn can surely be optimized)\u001b[39;00m\n\u001b[0;32m--> 145\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mall\u001b[39m(ent_subtype \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes \u001b[38;5;28;01mfor\u001b[39;00m ent_subtype \u001b[38;5;129;01min\u001b[39;00m sensed_entities), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPlease specify valid sensed entities among \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    146\u001b[0m     sensed_entities \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_subtype_label_to_idx[label] \u001b[38;5;28;01mfor\u001b[39;00m label \u001b[38;5;129;01min\u001b[39;00m sensed_entities]\n\u001b[1;32m    147\u001b[0m     sensed_type_left, sensed_type_right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprox_sensed_ent_type\n",
+      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py:149\u001b[0m, in \u001b[0;36mAgent.sensors\u001b[0;34m(self, sensed_entities)\u001b[0m\n\u001b[1;32m    146\u001b[0m left, right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mleft_prox, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mright_prox\n\u001b[1;32m    147\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m sensed_entities \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    148\u001b[0m     \u001b[38;5;66;03m# transform the strings of sensed entities into ints (this fn can surely be optimized)\u001b[39;00m\n\u001b[0;32m--> 149\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mall\u001b[39m(ent_subtype \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes \u001b[38;5;28;01mfor\u001b[39;00m ent_subtype \u001b[38;5;129;01min\u001b[39;00m sensed_entities), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPlease specify valid sensed entities among \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalid_subtypes\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    150\u001b[0m     sensed_entities \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_subtype_label_to_idx[label] \u001b[38;5;28;01mfor\u001b[39;00m label \u001b[38;5;129;01min\u001b[39;00m sensed_entities]\n\u001b[1;32m    151\u001b[0m     sensed_type_left, sensed_type_right \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprox_sensed_ent_type\n",
       "\u001b[0;31mAssertionError\u001b[0m: Please specify valid sensed entities among {'robots', 'resources', 'obstacles'}"
      ]
     }
@@ -397,14 +419,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.27164679765701294 0\n"
+      "0.5305280685424805 0\n"
      ]
     }
    ],
@@ -421,17 +443,6 @@
     "\n",
     "**Q2:** Define an `obstacle_avoidance` behavior. Obstacles are walls, pillars and trees, but not cups.  The robot has to turn in the direction opposite to the obstacle, with its speed inversely proportional to the proximeter activations (the closer an obstacle, the lower the speed). \n",
     "*Tip:* it is similar to the `shyness` behavior of [Braitenberg vehicles](https://docs.google.com/presentation/d/1s6ibk_ACiJb9CERJ_8L_b4KFu9d04ZG_htUbb_YSYT4/edit#slide=id.g31e1b425a3_0_0)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def obstacle_avoidance(epuck):\n",
-    "    # Write your code below\n",
-    "    pass\n"
    ]
   },
   {
@@ -484,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -497,12 +508,12 @@
       "Subtype: robots\n",
       "Idx: 0\n",
       "Exists: True\n",
-      "Position: x=100.59, y=269.16\n",
+      "Position: x=63.00, y=65.96\n",
       "\n",
-      "Sensors: Left=0.07, Right=0.44\n",
-      "Motors: Left=0.57, Right=0.94\n",
+      "Sensors: Left=0.57, Right=0.68\n",
+      "Motors: Left=0.00, Right=0.00\n",
       "\n",
-      "Available behaviors: ['obstacle_avoidance'], Active behaviors: ['obstacle_avoidance']\n"
+      "No behaviors attached\n"
      ]
     }
    ],
@@ -536,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,21 +583,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "measuring the number of steps per second in the controller for 2 seconds\n"
+      "measuring the FPS (number of steps per second) in the controller during 2 seconds\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FPS: 25.50 (number of steps per second in the controller)\n"
+      "FPS: 34.00\n"
      ]
     }
    ],
@@ -603,9 +614,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "new fn\n"
+     ]
+    }
+   ],
    "source": [
     "seconds = 2\n",
     "fps = 28\n",
@@ -616,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,35 +653,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
-    "controller.stop_ressources_apparition()"
+    "controller.stop_resources_apparition()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Remove all entities of a type"
+    "You can also remove all the entities of a certain type with this command:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Entity 4 already removed\n"
+      "Entity 6 already removed\n",
+      "Entity 7 already removed\n",
+      "Entity 8 already removed\n",
+      "Entity 10 already removed\n",
+      "Entity 11 already removed\n",
+      "Entity 12 already removed\n"
      ]
     }
    ],
    "source": [
     "controller.remove_entity_type(\"resources\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It will print an information message for all the non existing entities of this type we tried to remove (here, already non-existing ressources)."
    ]
   },
   {
@@ -676,11 +707,104 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "inf"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agent.time_since_last_meal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "agent.has_eaten_since(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "inf\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent.time_since_last_meal += 10\n",
+    "print(agent.time_since_last_meal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "inf\n"
+     ]
+    }
+   ],
+   "source": [
+    "agent.time_since_last_meal += 1000\n",
+    "print(agent.time_since_last_meal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "new fn\n"
+     ]
+    }
+   ],
+   "source": [
+    "controller.start_resources_apparition(interval=interval, position_range=((0, 50), (100, 200)))"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
-    "controller.start_resources_apparition(interval=interval, position_range=((0, 50), (100, 200)))"
+    "controller.stop_resources_apparition()"
    ]
   },
   {
@@ -730,20 +854,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def foraging(epuck):\n",
-    "    # Write your code below\n",
-    "    pass"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "def foraging(agent):\n",
     "    left, right = agent.sensors(sensed_entities=[\"resources\"])\n",
-    "    return right, left\n"
+    "    return right, left"
    ]
   },
   {
@@ -755,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -793,7 +906,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -847,15 +960,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Comment : Deleted line following \n",
-    "\n",
-    "Delete line following and replaced it by an activity on agents sensors (modify their range, their angle, etc...)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Dealing with multiple robots"
    ]
   },
@@ -863,18 +967,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This section explains how to deal with multiple robots and how to attach different behaviors to them.\n",
-    "\n",
-    "First close the current session:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO Later"
+    "This section explains how to deal with multiple robots and how to attach different behaviors to them."
    ]
   },
   {
@@ -899,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +1001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -932,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,26 +1036,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "'spawn_entity_routine_fn'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[42], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcontroller\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstop_ressources_apparition\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m controller\u001b[38;5;241m.\u001b[39mstart_resources_apparition(interval\u001b[38;5;241m=\u001b[39minterval)\n",
-      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py:485\u001b[0m, in \u001b[0;36mstop_ressources_apparition\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    484\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mstop_ressources_apparition\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[0;32m--> 485\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Stop the resources apparition process\u001b[39;00m\n\u001b[1;32m    486\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m    487\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdetach_routine(spawn_entity_routine_fn\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m)\n",
-      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/notebook_controller.py:564\u001b[0m, in \u001b[0;36mdetach_routine\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m    561\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mdetach_routine\u001b[39m(\u001b[38;5;28mself\u001b[39m, name):\n\u001b[1;32m    562\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Detach a routine from the entity\u001b[39;00m\n\u001b[1;32m    563\u001b[0m \n\u001b[0;32m--> 564\u001b[0m \u001b[38;5;124;03m    :param name: routine name\u001b[39;00m\n\u001b[1;32m    565\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m    566\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroutine_handler\u001b[38;5;241m.\u001b[39mdetach_routine(name)\n",
-      "File \u001b[0;32m~/Desktop/code/vivarium/vivarium/controllers/utils.py:65\u001b[0m, in \u001b[0;36mRoutineHandler.detach_routine\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m     60\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mdetach_routine\u001b[39m(\u001b[38;5;28mself\u001b[39m, name):\n\u001b[1;32m     61\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Detach a routine from the entity\u001b[39;00m\n\u001b[1;32m     62\u001b[0m \n\u001b[1;32m     63\u001b[0m \u001b[38;5;124;03m    :param name: routine name\u001b[39;00m\n\u001b[1;32m     64\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 65\u001b[0m     \u001b[38;5;28;01mdel\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_routines[name]\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'spawn_entity_routine_fn'"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Resources apparition is already stopped\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "new fn\n"
      ]
     }
    ],
    "source": [
-    "controller.stop_ressources_apparition()\n",
+    "controller.stop_resources_apparition()\n",
     "controller.start_resources_apparition(interval=interval)"
    ]
   },
@@ -977,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1007,7 +1100,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vivarium.controllers.notebook_controller import NotebookController\n",
+    "controller = NotebookController()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controller.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,7 +1129,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_0 = controller.agents[0]\n",
+    "agent_1 = controller.agents[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1032,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1049,7 +1171,7 @@
     "agent_1.diameter = 4.\n",
     "agent_1.color = 'cyan'\n",
     "# Make the little agent go faster\n",
-    "agent_1.wheel_diameter = 4.\n"
+    "agent_1.wheel_diameter = 4."
    ]
   },
   {
@@ -1074,7 +1196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1115,7 +1237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -1142,7 +1264,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/sessions/session_4.ipynb
+++ b/notebooks/sessions/session_4.ipynb
@@ -126,6 +126,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "/home/cleger/Desktop/code/vivarium/vivarium/utils\n",
       "STARTING SERVER\n"
      ]
     },
@@ -140,8 +141,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2024-11-06 14:34:50,711][__main__][INFO] - Scene running: session_4\n",
-      "[2024-11-06 14:34:53,220][vivarium.simulator.simulator][INFO] - Simulator initialized\n",
+      "[2024-11-26 17:12:26,026][__main__][INFO] - Scene running: session_4\n",
+      "[2024-11-26 17:12:28,522][vivarium.simulator.simulator][INFO] - Simulator initialized\n",
       "\n",
       "STARTING INTERFACE\n"
      ]
@@ -150,13 +151,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-11-06 14:34:55,261 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
-      "2024-11-06 14:34:55,262 User authentication hooks NOT provided (default user enabled)\n",
-      "2024-11-06 14:34:55,264 Bokeh app running at: http://localhost:5006/run_interface\n",
-      "2024-11-06 14:34:55,264 Starting Bokeh server with process id: 8283\n",
-      "2024-11-06 14:34:57,811 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
-      "2024-11-06 14:34:59,707 WebSocket connection opened\n",
-      "2024-11-06 14:34:59,738 ServerConnection created\n"
+      "2024-11-26 17:12:30,419 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
+      "2024-11-26 17:12:30,420 User authentication hooks NOT provided (default user enabled)\n",
+      "2024-11-26 17:12:30,421 Bokeh app running at: http://localhost:5006/run_interface\n",
+      "2024-11-26 17:12:30,421 Starting Bokeh server with process id: 50178\n",
+      "2024-11-26 17:12:32,321 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
+      "2024-11-26 17:12:34,015 WebSocket connection opened\n",
+      "2024-11-26 17:12:34,044 ServerConnection created\n"
      ]
     }
    ],
@@ -166,11 +167,29 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/jax/_src/ops/scatter.py:96: FutureWarning: scatter inputs have incompatible types: cannot safely cast value from dtype=float32 to dtype=int32 with jax_numpy_dtype_promotion='standard'. In future JAX releases this will result in an error.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "controller = NotebookController()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "controller = NotebookController()"
+    "controller.run()"
    ]
   },
   {
@@ -179,33 +198,22 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error while executing routine: 'super' object has no attribute '__getattr__', removing routine foraging_drive\n",
-      "Error while executing routine: 'super' object has no attribute '__getattr__', removing routine foraging_drive\n"
+      "measuring the FPS (number of steps per second) in the controller during 2 seconds\n"
      ]
-    }
-   ],
-   "source": [
-    "controller.run()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FPS: 162.00 (number of steps per second)\n"
+      "FPS: 25.00\n"
      ]
     }
    ],
    "source": [
-    "controller.get_fps()"
+    "controller.print_fps()"
    ]
   },
   {
@@ -245,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -271,26 +279,24 @@
    ],
    "source": [
     "for agent in controller.agents:\n",
-    "    agent.check_behaviors()"
+    "    agent.print_behaviors()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "controller.start_resources_apparition(period=10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Update agents diet\n",
     "for agent in controller.agents:\n",
-    "    agent.diet = [\"resources\"]"
+    "    agent.diet = [\"resources\"]\n",
+    "\n",
+    "# Start resources apparition\n",
+    "controller.start_resources_apparition(interval=60)\n",
+    "\n",
+    "# Start the eating mechanism\n",
+    "controller.start_eating_mechanism(interval=10)"
    ]
   },
   {
@@ -330,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,6 +410,58 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(controller.routine_handler._routines)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controller.pause()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controller.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Update agents diet\n",
+    "for agent in controller.agents:\n",
+    "    agent.diet = [\"resources\"]\n",
+    "\n",
+    "# Start resources apparition\n",
+    "controller.start_resources_apparition(interval=60)\n",
+    "\n",
+    "# Start the eating mechanism\n",
+    "controller.start_eating_mechanism(interval=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -411,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -443,7 +501,7 @@
     "    robot.attach_behavior(obstacle_avoidance, weight=1)\n",
     "    robot.attach_behavior(fear, weight=0.5)\n",
     "    robot.start_all_behaviors()\n",
-    "    robot.check_behaviors()"
+    "    robot.print_behaviors()"
    ]
   },
   {
@@ -464,24 +522,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This weighting is particularly useful to activate a behavior according to some internal states of the robot. Let's consider a robot that eats spheres (as in the previous session) and that eating those spheres allows to raise a simulated energy level of the robot. We want to continuously compute the energy level of the robot according to how much spheres it has recently eaten. To do so, we first need a way to know when a robot eats a sphere. For example to check it on robot 2, this is done by executing:"
+    "This weighting is particularly useful to activate a behavior according to some internal states of the robot. Let's consider a robot that eats spheres (as in the previous session) and that eating those spheres allows to raise a simulated energy level of the robot. We want to continuously compute the energy level of the robot according to how much spheres it has recently eaten. To do so, we first need a way to know when a robot has eaten for the last time. There are several ways of doing this that can serve in different use cases:\n",
+    "\n",
+    "- agent.has_eaten(): function that tells if the agent has eaten since the last call to this function, defaults to False\n",
+    "- agent.time_since_last_meal: attribute that tells the time since the last meal, defaults to infinity when the agent has never eaten\n",
+    "- agent.has_eaten_since(t): function that tells if the agent has eaten since time t"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "True\n"
+      "True\n",
+      "101\n",
+      "False\n"
      ]
     }
    ],
    "source": [
-    "print(robot_2.has_eaten())"
+    "print(robot_2.has_eaten())\n",
+    "print(robot_2.time_since_last_meal)\n",
+    "print(robot_2.has_eaten_since(50))"
    ]
   },
   {
@@ -493,22 +559,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "robot 0 has eaten : True\n",
-      "robot 1 has eaten : True\n",
-      "robot 2 has eaten : True\n"
+      "robot 0: -ate: False -time since last meal: inf\n",
+      "robot 1: -ate: True -time since last meal: 0\n",
+      "robot 2: -ate: False -time since last meal: 110\n"
      ]
     }
    ],
    "source": [
     "for robot in controller.agents:\n",
-    "    print(f\"robot {robot.idx} has eaten : {robot.has_eaten()}\")"
+    "    print(f\"robot {robot.idx}: -ate: {robot.has_eaten()} -time since last meal: {robot.time_since_last_meal}\")"
    ]
   },
   {
@@ -520,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 35,
    "metadata": {
     "collapsed": true
    },
@@ -535,18 +601,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "measuring the FPS (number of steps per second) in the controller during 2 seconds\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FPS: 26.00\n"
+     ]
+    }
+   ],
    "source": [
-    "# First start sphere apparition faster in the environment:\n",
-    "controller.stop_entity_apparition()\n",
-    "controller.start_entity_apparition(period=5, entity_type=\"resources\")"
+    "controller.print_fps()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First start sphere apparition faster in the environment:\n",
+    "controller.stop_resources_apparition()\n",
+    "controller.start_resources_apparition(interval=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,23 +646,6 @@
     "    robot.attach_behavior(obstacle_avoidance, interval=10)\n",
     "    robot.attach_behavior(foraging, interval=10)\n",
     "    robot.start_all_behaviors()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FPS: 132.00 (number of steps per second)\n"
-     ]
-    }
-   ],
-   "source": [
-    "controller.get_fps()"
    ]
   },
   {
@@ -596,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -627,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 41,
    "metadata": {
     "collapsed": true
    },
@@ -654,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 42,
    "metadata": {
     "collapsed": true
    },
@@ -705,14 +778,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "97.12999999999853\n"
+      "59.18000000000016\n"
      ]
     }
    ],
@@ -722,14 +795,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "96.69999999999831\n"
+      "59.05000000000019\n"
      ]
     }
    ],
@@ -776,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 45,
    "metadata": {
     "collapsed": true
    },
@@ -795,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 46,
    "metadata": {
     "collapsed": true
    },
@@ -826,59 +899,126 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To return sensed entities by left and right proximeters, we can use the `sensed_entities` function of the agents. This returns the left and right entities if they are sensed, and `None` otherwise. "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ent_l, ent_r = robot_0.sensed_entities()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check what are the entities detected by a robot by running the following cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Left:\n",
-      "Entity Overview:\n",
-      "--------------------\n",
-      "Type: OBJECT\n",
-      "Subtype: b_obstacles\n",
-      "Idx: 29\n",
-      "Position: x=67.39, y=178.52\n",
+      "Left entity:\n",
+      "No entity sensed\n",
       "\n",
-      "Right:\n",
+      "Right entity:\n",
       "Entity Overview:\n",
       "--------------------\n",
       "Type: OBJECT\n",
-      "Subtype: s_obstacles\n",
-      "Idx: 18\n",
-      "Position: x=110.49, y=121.34\n",
+      "Subtype: resources\n",
+      "Idx: 9\n",
+      "Exists: True\n",
+      "Position: x=172.37, y=274.10\n",
       "\n"
      ]
     }
    ],
    "source": [
+    "# Give a specific color to robot_0 to recognize him\n",
+    "robot_0.color = \"black\"\n",
+    "# Sense entities on the left and right of robot_0\n",
     "ent_l, ent_r = robot_0.sensed_entities()\n",
-    "print(\"Left:\")\n",
-    "ent_l.infos()\n",
     "\n",
-    "print(\"Right:\")\n",
-    "ent_r.infos()"
+    "# Print the infos of the sensed entities\n",
+    "print(\"Left entity:\")\n",
+    "if ent_l:\n",
+    "    ent_l.print_infos()\n",
+    "else:\n",
+    "    print(\"No entity sensed\")\n",
+    "\n",
+    "print(\"\\nRight entity:\")\n",
+    "if ent_r:\n",
+    "    ent_r.print_infos()\n",
+    "else:\n",
+    "    print(\"No entity sensed\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also directly sense specific attributes of these sensed entities with the `sense_attributes` function. Make sure to specify the `sensed_attribute` you want to sense (e.g 'diameter', 'species', etc.). You can also specify the `default_value` value to return if the attribute is not found (otherwise it is set to None). The function will return the given attribute of the left and right sensed entities if it exists (it can be either if the entity doesn't exist, or because the entity doesn't possess the specific attribute), and the default value otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, each entity has a diameter, so if you see a `None` value, it means that the entity isn't sensed by the agent."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Left: None Right: None\n"
+      "Left: None Right: 5.0\n"
      ]
     }
    ],
    "source": [
-    "# attribute = \"x_position\"\n",
-    "attribute = \"species\"\n",
-    "l_attr, r_attr = robot_0.sense_attributes(sensed_attribute=attribute)\n",
+    "l_attr, r_attr = robot_0.sense_attributes(sensed_attribute=\"diameter\",)\n",
+    "print(f\"Left: {l_attr} Right: {r_attr}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this other case, we only defined species for the robots. We set the default value to 'unknown', so if an entity isn't detected, or doesn't have the attribute, it will return 'unknown'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Left: unknown Right: unknown\n"
+     ]
+    }
+   ],
+   "source": [
+    "l_attr, r_attr = robot_0.sense_attributes(sensed_attribute=\"species\", default_value=\"unknown\")\n",
     "print(f\"Left: {l_attr} Right: {r_attr}\")"
    ]
   },
@@ -900,7 +1040,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 73,
    "metadata": {
     "collapsed": true
    },
@@ -923,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -935,7 +1075,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -947,7 +1087,7 @@
     }
    ],
    "source": [
-    "robot_2.check_behaviors()\n",
+    "robot_2.print_behaviors()\n",
     "robot_2.color = \"silver\""
    ]
   },
@@ -960,7 +1100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 77,
    "metadata": {
     "collapsed": true
    },
@@ -987,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 78,
    "metadata": {
     "collapsed": true
    },
@@ -999,7 +1139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 79,
    "metadata": {
     "collapsed": true
    },
@@ -1017,14 +1157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -1067,7 +1200,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/sessions/session_5_bonus.ipynb
+++ b/notebooks/sessions/session_5_bonus.ipynb
@@ -22,7 +22,15 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -36,19 +44,41 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "FileNotFoundError",
-     "evalue": "[WinError 2] The system cannot find the file specified",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[2], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mstart_server_and_interface\u001b[49m\u001b[43m(\u001b[49m\u001b[43mscene_name\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43msession_5\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[1;32mc:\\users\\coren\\desktop\\code\\vivarium\\vivarium\\utils\\handle_server_interface.py:42\u001b[0m, in \u001b[0;36mstart_server_and_interface\u001b[1;34m(scene_name, notebook_mode, wait_time)\u001b[0m\n\u001b[0;32m     36\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Start the server and interface for the given scene\u001b[39;00m\n\u001b[0;32m     37\u001b[0m \n\u001b[0;32m     38\u001b[0m \u001b[38;5;124;03m:param scene_name: scene name\u001b[39;00m\n\u001b[0;32m     39\u001b[0m \u001b[38;5;124;03m:param notebook_mode: notebook_mode to adapt the interface, defaults to True\u001b[39;00m\n\u001b[0;32m     40\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m     41\u001b[0m \u001b[38;5;66;03m# first ensure no interface or server is running\u001b[39;00m\n\u001b[1;32m---> 42\u001b[0m \u001b[43mstop_server_and_interface\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     43\u001b[0m \u001b[38;5;66;03m# find the path to the server and interface scripts\u001b[39;00m\n\u001b[0;32m     44\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mos\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mdirname(\u001b[38;5;18m__file__\u001b[39m)\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
-      "File \u001b[1;32mc:\\users\\coren\\desktop\\code\\vivarium\\vivarium\\utils\\handle_server_interface.py:84\u001b[0m, in \u001b[0;36mstop_server_and_interface\u001b[1;34m()\u001b[0m\n\u001b[0;32m     82\u001b[0m stopped \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[0;32m     83\u001b[0m \u001b[38;5;66;03m# interface_process_name = \"vivarium/scripts/run_interface.py\"\u001b[39;00m\n\u001b[1;32m---> 84\u001b[0m interface_pid \u001b[38;5;241m=\u001b[39m \u001b[43mget_process_pid\u001b[49m\u001b[43m(\u001b[49m\u001b[43mINTERFACE_PROCESS_NAME\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     85\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m interface_pid \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     86\u001b[0m     kill_process(interface_pid)\n",
-      "File \u001b[1;32mc:\\users\\coren\\desktop\\code\\vivarium\\vivarium\\utils\\handle_server_interface.py:19\u001b[0m, in \u001b[0;36mget_process_pid\u001b[1;34m(process_name)\u001b[0m\n\u001b[0;32m     13\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mget_process_pid\u001b[39m(process_name: \u001b[38;5;28mstr\u001b[39m):\n\u001b[0;32m     14\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Get the process ID of a running process by name\u001b[39;00m\n\u001b[0;32m     15\u001b[0m \n\u001b[0;32m     16\u001b[0m \u001b[38;5;124;03m    :param process_name: process name\u001b[39;00m\n\u001b[0;32m     17\u001b[0m \u001b[38;5;124;03m    :return: process ID\u001b[39;00m\n\u001b[0;32m     18\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m---> 19\u001b[0m     process \u001b[38;5;241m=\u001b[39m \u001b[43msubprocess\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mPopen\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mps\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43maux\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstdout\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msubprocess\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mPIPE\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     20\u001b[0m     out, err \u001b[38;5;241m=\u001b[39m process\u001b[38;5;241m.\u001b[39mcommunicate()\n\u001b[0;32m     21\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m line \u001b[38;5;129;01min\u001b[39;00m out\u001b[38;5;241m.\u001b[39msplitlines():\n",
-      "File \u001b[1;32mC:\\Program Files\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\\lib\\subprocess.py:971\u001b[0m, in \u001b[0;36mPopen.__init__\u001b[1;34m(self, args, bufsize, executable, stdin, stdout, stderr, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags, restore_signals, start_new_session, pass_fds, user, group, extra_groups, encoding, errors, text, umask, pipesize)\u001b[0m\n\u001b[0;32m    967\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtext_mode:\n\u001b[0;32m    968\u001b[0m             \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstderr \u001b[38;5;241m=\u001b[39m io\u001b[38;5;241m.\u001b[39mTextIOWrapper(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstderr,\n\u001b[0;32m    969\u001b[0m                     encoding\u001b[38;5;241m=\u001b[39mencoding, errors\u001b[38;5;241m=\u001b[39merrors)\n\u001b[1;32m--> 971\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_execute_child\u001b[49m\u001b[43m(\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mexecutable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreexec_fn\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mclose_fds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    972\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mpass_fds\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43menv\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    973\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mstartupinfo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcreationflags\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshell\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    974\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mp2cread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mp2cwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    975\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mc2pread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mc2pwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    976\u001b[0m \u001b[43m                        \u001b[49m\u001b[43merrread\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43merrwrite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    977\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mrestore_signals\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    978\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mgid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mgids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43muid\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mumask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    979\u001b[0m \u001b[43m                        \u001b[49m\u001b[43mstart_new_session\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m    980\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[0;32m    981\u001b[0m     \u001b[38;5;66;03m# Cleanup if the child failed starting.\u001b[39;00m\n\u001b[0;32m    982\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m f \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mfilter\u001b[39m(\u001b[38;5;28;01mNone\u001b[39;00m, (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstdin, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstdout, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstderr)):\n",
-      "File \u001b[1;32mC:\\Program Files\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\\lib\\subprocess.py:1456\u001b[0m, in \u001b[0;36mPopen._execute_child\u001b[1;34m(self, args, executable, preexec_fn, close_fds, pass_fds, cwd, env, startupinfo, creationflags, shell, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, unused_restore_signals, unused_gid, unused_gids, unused_uid, unused_umask, unused_start_new_session)\u001b[0m\n\u001b[0;32m   1454\u001b[0m \u001b[38;5;66;03m# Start the process\u001b[39;00m\n\u001b[0;32m   1455\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[1;32m-> 1456\u001b[0m     hp, ht, pid, tid \u001b[38;5;241m=\u001b[39m \u001b[43m_winapi\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mCreateProcess\u001b[49m\u001b[43m(\u001b[49m\u001b[43mexecutable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m   1457\u001b[0m \u001b[43m                             \u001b[49m\u001b[38;5;66;43;03m# no special security\u001b[39;49;00m\n\u001b[0;32m   1458\u001b[0m \u001b[43m                             \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[0;32m   1459\u001b[0m \u001b[43m                             \u001b[49m\u001b[38;5;28;43mint\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;129;43;01mnot\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43mclose_fds\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m   1460\u001b[0m \u001b[43m                             \u001b[49m\u001b[43mcreationflags\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m   1461\u001b[0m \u001b[43m                             \u001b[49m\u001b[43menv\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m   1462\u001b[0m \u001b[43m                             \u001b[49m\u001b[43mcwd\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m   1463\u001b[0m \u001b[43m                             \u001b[49m\u001b[43mstartupinfo\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   1464\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[0;32m   1465\u001b[0m     \u001b[38;5;66;03m# Child is launched. Close the parent's copy of those pipe\u001b[39;00m\n\u001b[0;32m   1466\u001b[0m     \u001b[38;5;66;03m# handles that only the child should have open.  You need\u001b[39;00m\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m   1469\u001b[0m     \u001b[38;5;66;03m# pipe will not close when the child process exits and the\u001b[39;00m\n\u001b[0;32m   1470\u001b[0m     \u001b[38;5;66;03m# ReadFile will hang.\u001b[39;00m\n\u001b[0;32m   1471\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_close_pipe_fds(p2cread, p2cwrite,\n\u001b[0;32m   1472\u001b[0m                          c2pread, c2pwrite,\n\u001b[0;32m   1473\u001b[0m                          errread, errwrite)\n",
-      "\u001b[1;31mFileNotFoundError\u001b[0m: [WinError 2] The system cannot find the file specified"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/cleger/Desktop/code/vivarium/vivarium/utils\n",
+      "STARTING SERVER\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2024-11-25 14:48:18,993][__main__][INFO] - Scene running: session_5\n",
+      "[2024-11-25 14:48:21,668][vivarium.simulator.simulator][INFO] - Simulator initialized\n",
+      "\n",
+      "STARTING INTERFACE\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-11-25 14:48:23,580 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
+      "2024-11-25 14:48:23,580 User authentication hooks NOT provided (default user enabled)\n",
+      "2024-11-25 14:48:23,582 Bokeh app running at: http://localhost:5006/run_interface\n",
+      "2024-11-25 14:48:23,582 Starting Bokeh server with process id: 33727\n",
+      "2024-11-25 14:48:36,107 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
+      "2024-11-25 14:48:38,248 WebSocket connection opened\n",
+      "2024-11-25 14:48:38,298 ServerConnection created\n"
      ]
     }
    ],
@@ -65,15 +95,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "controller = NotebookController()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [
@@ -81,17 +102,27 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Error while executing routine: name 'offspring_diameter' is not defined, removing routine sexual_reproduction\n"
+      "/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/jax/_src/ops/scatter.py:96: FutureWarning: scatter inputs have incompatible types: cannot safely cast value from dtype=float32 to dtype=int32 with jax_numpy_dtype_promotion='standard'. In future JAX releases this will result in an error.\n",
+      "  warnings.warn(\n"
      ]
     }
    ],
+   "source": [
+    "controller = NotebookController()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "controller.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -162,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -187,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -221,7 +252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,16 +270,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<vivarium.controllers.notebook_controller.Agent at 0x18edd3c6020>"
+       "<vivarium.controllers.notebook_controller.Agent at 0x7195a8d01990>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,9 +316,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Entity 5 already removed\n"
+     ]
+    }
+   ],
    "source": [
     "agent_idx = 5 # idx of an alive agent\n",
     "controller.remove_entity(agent_idx)"
@@ -297,8 +336,86 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now you have the basics to make agents spwan and die ! \n",
+    "Now you have the basics to make agents spwan and die ! "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see how to manipulate dead and alive agents lists now, you can either get these lists manually:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting existing agents manually: \n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Getting existing agents manually: \")\n",
+    "for agent in controller.agents:\n",
+    "    if agent.exists == True:\n",
+    "        print(agent.idx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But you also have helper attributes to do that :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting existing agents with an attribute: \n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "3\n",
+      "\n",
+      "Getting non existing agents with an attribute: \n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Getting existing agents with an attribute: \")\n",
+    "for agent in controller.existing_agents:\n",
+    "    print(agent.idx)\n",
     "\n",
+    "print(\"\\nGetting non existing agents with an attribute: \")\n",
+    "for agent in controller.non_existing_agents:\n",
+    "    print(agent.idx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Attach behaviors to existing agents (you can technically also attach them to dead agents but it won't have any effect):"
    ]
   },
@@ -1280,7 +1397,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myvenv",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -1294,7 +1411,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/sessions/session_5_bonus.ipynb
+++ b/notebooks/sessions/session_5_bonus.ipynb
@@ -22,19 +22,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
-    "from vivarium.controllers.notebook_controller import NotebookController\n",
     "from vivarium.utils.handle_server_interface import start_server_and_interface, stop_server_and_interface"
    ]
   },
@@ -62,23 +53,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2024-11-25 14:48:18,993][__main__][INFO] - Scene running: session_5\n",
-      "[2024-11-25 14:48:21,668][vivarium.simulator.simulator][INFO] - Simulator initialized\n",
+      "[2024-11-26 11:44:55,762][__main__][INFO] - Scene running: session_5\n",
+      "[2024-11-26 11:44:58,396][vivarium.simulator.simulator][INFO] - Simulator initialized\n",
       "\n",
       "STARTING INTERFACE\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-11-25 14:48:23,580 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
-      "2024-11-25 14:48:23,580 User authentication hooks NOT provided (default user enabled)\n",
-      "2024-11-25 14:48:23,582 Bokeh app running at: http://localhost:5006/run_interface\n",
-      "2024-11-25 14:48:23,582 Starting Bokeh server with process id: 33727\n",
-      "2024-11-25 14:48:36,107 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
-      "2024-11-25 14:48:38,248 WebSocket connection opened\n",
-      "2024-11-25 14:48:38,298 ServerConnection created\n"
      ]
     }
    ],
@@ -102,12 +80,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "2024-11-26 11:45:00,237 Starting Bokeh server version 3.3.4 (running on Tornado 6.4)\n",
+      "2024-11-26 11:45:00,237 User authentication hooks NOT provided (default user enabled)\n",
+      "2024-11-26 11:45:00,239 Bokeh app running at: http://localhost:5006/run_interface\n",
+      "2024-11-26 11:45:00,239 Starting Bokeh server with process id: 22097\n",
+      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
       "/home/cleger/Desktop/code/vivarium/venv/lib/python3.10/site-packages/jax/_src/ops/scatter.py:96: FutureWarning: scatter inputs have incompatible types: cannot safely cast value from dtype=float32 to dtype=int32 with jax_numpy_dtype_promotion='standard'. In future JAX releases this will result in an error.\n",
       "  warnings.warn(\n"
      ]
     }
    ],
    "source": [
+    "from vivarium.controllers.notebook_controller import NotebookController\n",
+    "\n",
     "controller = NotebookController()"
    ]
   },
@@ -252,13 +237,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n"
+     ]
+    }
+   ],
    "source": [
     "agent_idx = 4 # idx of a dead agent\n",
     "agent = controller.agents[agent_idx]\n",
-    "agent.exists = True # make the agent spawn"
+    "agent.exists = True # make the agent spawn\n",
+    "print(agent.exists)"
    ]
   },
   {
@@ -270,16 +264,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<vivarium.controllers.notebook_controller.Agent at 0x7195a8d01990>"
+       "<vivarium.controllers.notebook_controller.Agent at 0x6ffd26f4b4f0>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -323,7 +317,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Entity 5 already removed\n"
+      "2024-11-26 11:45:18,584 An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n",
+      "2024-11-26 11:45:20,336 WebSocket connection opened\n",
+      "2024-11-26 11:45:20,386 ServerConnection created\n"
      ]
     }
    ],
@@ -348,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -379,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -416,25 +412,186 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Attach behaviors to existing agents (you can technically also attach them to dead agents but it won't have any effect):"
+    "Attach behaviors to existing agents (you can technically also attach them to dead agents but it won't have any effect, since their behaviors won't be executed):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "for agent in controller.agents:\n",
-    "    if agent.exists == True:\n",
-    "        agent.attach_behavior(obstacle_avoidance)\n",
-    "        agent.attach_behavior(love_cuddly)\n",
-    "        agent.start_all_behaviors()"
+    "for agent in controller.existing_agents:\n",
+    "    agent.attach_behavior(obstacle_avoidance)\n",
+    "    agent.attach_behavior(love_cuddly)\n",
+    "    agent.start_all_behaviors()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "agent 0: exists = True\n",
+      "agent 1: exists = True\n",
+      "agent 2: exists = True\n",
+      "agent 3: exists = True\n",
+      "agent 4: exists = True\n",
+      "agent 5: exists = True\n",
+      "agent 6: exists = False\n",
+      "agent 7: exists = False\n",
+      "agent 8: exists = False\n",
+      "agent 9: exists = False\n"
+     ]
+    }
+   ],
+   "source": [
+    "for agent in controller.agents:\n",
+    "    print(f\"agent {agent.idx}: exists = {agent.exists}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def old():\n",
+    "    \"\"\"make agents of the simulation eating the entities in their diet\n",
+    "\n",
+    "    :param controller: NotebookController\n",
+    "    \"\"\"\n",
+    "    for agent in controller.agents:\n",
+    "        # skip to next agent if the agent does not exist\n",
+    "        if not agent.exists:\n",
+    "            continue\n",
+    "        for entity_type in agent.diet:\n",
+    "            assert entity_type in controller.valid_subtypes, f\"Please specify a valid entity type among {controller.valid_subtypes}, for agent {agent.idx} diet : {agent.diet} \"\n",
+    "            # transform the entity type label into an idx\n",
+    "            entity_type = controller._subtype_label_to_idx[entity_type]\n",
+    "            # get the idx of entities that are eatable by the agent (by precaution remove the agent itself)\n",
+    "            eatable_entities_idx = [ent.idx for ent in controller.all_entities if ent.subtype == entity_type and ent.idx != agent.idx]\n",
+    "            distances = agent.config.proximity_map_dist[eatable_entities_idx]\n",
+    "            in_range = distances < agent.eating_range\n",
+    "            # arr_idx is the index of the in_range array\n",
+    "            for arr_idx, ent_idx in enumerate(eatable_entities_idx):\n",
+    "                if in_range[arr_idx] and controller.all_entities[ent_idx].exists:\n",
+    "                    controller.remove_entity(ent_idx)\n",
+    "                    # TODO : check here \n",
+    "                    agent.time_since_last_meal = 0    \n",
+    "\n",
+    "\n",
+    "def new():\n",
+    "    \"\"\"Routine to make agents eat entities in their diet. \n",
+    "    They can only eat entities sensed by their proximeters, and that are in their eating range.\n",
+    "\n",
+    "    :param controller: _description_\n",
+    "    \"\"\"\n",
+    "    for agent in controller.existing_agents:\n",
+    "        left_prox, right_prox = agent.sensors()\n",
+    "        left_type, right_type = agent.prox_sensed_ent_type\n",
+    "\n",
+    "        can_eat_left = (\n",
+    "            controller.subtypes_labels[left_type] in agent.diet and\n",
+    "            (1. - left_prox) * agent.proxs_dist_max <= agent.eating_range\n",
+    "        )\n",
+    "\n",
+    "        can_eat_right = (\n",
+    "            controller.subtypes_labels[right_type] in agent.diet and\n",
+    "            (1. - right_prox) * agent.proxs_dist_max <= agent.eating_range\n",
+    "        )\n",
+    "\n",
+    "        # if the agent can eat\n",
+    "        if can_eat_left or can_eat_right:\n",
+    "            # determine which side to eat\n",
+    "            if can_eat_left and can_eat_right:\n",
+    "                eating_choice = np.random.choice([0, 1])\n",
+    "            else:\n",
+    "                eating_choice = 0 if can_eat_left else 1\n",
+    "            \n",
+    "            controller.remove_entity(agent.prox_sensed_ent_idx[eating_choice])\n",
+    "        # TODO : update the mechanism to update the has eaten since time\n",
+    "            agent.ate = True\n",
+    "        else:\n",
+    "            agent.ate = False\n",
+    "\n",
+    "\n",
+    "def clem():\n",
+    "    \"\"\"make agents of the simulation eating the entities in their diet\n",
+    "\n",
+    "    :param controller: NotebookController\n",
+    "    \"\"\"\n",
+    "\n",
+    "    for agent in controller.agents:\n",
+    "        if agent.exists:\n",
+    "            left, right = agent.config.left_prox, agent.config.right_prox\n",
+    "            sensed_type_left, sensed_type_right = agent.prox_sensed_ent_type\n",
+    "            eat_left = controller.subtypes_labels[sensed_type_left] in agent.diet and (1. - left) * agent.proxs_dist_max <= agent.eating_range\n",
+    "            eat_right = controller.subtypes_labels[sensed_type_right] in agent.diet and (1. - right) * agent.proxs_dist_max <= agent.eating_range\n",
+    "            ate = True\n",
+    "            if eat_left:\n",
+    "                if eat_right:\n",
+    "                    which =  np.random.rand() < 0.5\n",
+    "                    controller.remove_entity(agent.prox_sensed_ent_idx[int(which)])\n",
+    "                else:\n",
+    "                    controller.remove_entity(agent.prox_sensed_ent_idx[0])\n",
+    "            else:\n",
+    "                if eat_right:\n",
+    "                    controller.remove_entity(agent.prox_sensed_ent_idx[1])\n",
+    "                else:\n",
+    "                    ate = False\n",
+    "            agent.ate = ate\n",
+    "\n",
+    "    return"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Old took 0.806134 seconds\n",
+      "New took 1.754245 seconds\n",
+      "Clem took 1.760777 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "import timeit\n",
+    "\n",
+    "from functools import partial\n",
+    "\n",
+    "num_iterations = 1000\n",
+    "\n",
+    "new = timeit.timeit(new, number=num_iterations)\n",
+    "old = timeit.timeit(old, number=num_iterations)\n",
+    "clem = timeit.timeit(clem, number=num_iterations)\n",
+    "\n",
+    "print(f\"Old took {old:.6f} seconds\")\n",
+    "print(f\"New took {new:.6f} seconds\")\n",
+    "print(f\"Clem took {clem:.6f} seconds\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controller.stop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -461,7 +618,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controller.run(catch_errors=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +762,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1377,7 +1543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {

--- a/vivarium/controllers/notebook_controller.py
+++ b/vivarium/controllers/notebook_controller.py
@@ -156,15 +156,14 @@ class Agent(Entity):
         return [left, right]
 
     def sensed_entities(self):
-        """Return the left and right sensed entities of the agent
+        """Return the left and right sensed entities of the agent if they are sensed, else None
 
         :return: sensed entities
         """
         left_idx, right_idx = self.prox_sensed_ent_idx
-        return [
-            self.simulation_entities[left_idx], 
-            self.simulation_entities[right_idx]
-        ]
+        left_ent = self.simulation_entities[left_idx] if self.config.left_prox != 0 else None
+        right_ent = self.simulation_entities[right_idx] if self.config.right_prox != 0 else None
+        return [left_ent, right_ent]
     
     def sense_attributes(self, sensed_attribute, default_value=None):
         """Return the sensed attribute of the left and right sensed entities
@@ -561,13 +560,18 @@ class NotebookController(SimulatorController):
             run_time += 1
 
         # finally stop the simulation
-        self.stop()
+        self.pause()
 
     def stop(self):
-        """Stop the simulation
+        """Stop the simulation and detach all routines
         """
         self._is_running = False
         self.routine_handler.detach_all_routines()
+
+    def pause(self):
+        """Pause the simulation
+        """
+        self._is_running = False
 
     def wait(self, seconds):
         """Wait for a given number of seconds

--- a/vivarium/controllers/notebook_controller.py
+++ b/vivarium/controllers/notebook_controller.py
@@ -106,7 +106,6 @@ class Entity:
         
         return print("\n".join(info_lines))
     
-    # TODO : Add this in tests
     def print_routines(self):
         """Print the entity's routines
         """
@@ -237,7 +236,6 @@ class Agent(Entity):
         n = name.__name__ if hasattr(name, "__name__") else name
         del self.active_behaviors[n]
 
-    # TODO : add interval execution for behaviors
     def print_behaviors(self):
         """Print the behaviors and active behaviors of the agent
         """
@@ -326,20 +324,6 @@ class Agent(Entity):
         sensors = self.sensors()
         info_lines.append(f"Sensors: Left={sensors[0]:.2f}, Right={sensors[1]:.2f}")
         info_lines.append(f"Motors: Left={self.left_motor:.2f}, Right={self.right_motor:.2f}")
-        
-        # TODO : see if we print behaviors and eating infos by default
-        # List behaviors
-        # if self.behaviors:
-        #     info_lines.append("Behaviors:")
-        #     for name, (behavior_fn, weight) in self.behaviors.items():
-        #         info_lines.append(f"  - {name}: Function={behavior_fn.__name__}, Weight={weight}")
-        # else:
-        #     info_lines.append("Behaviors: None")
-
-        # See if we print that by default
-        # info_lines.append('') # add a space between other infos and eating infos atm
-        # info_lines.append(f"Diet: {self.diet}")
-        # info_lines.append(f"Eating range: {self.eating_range}")
         
         dict_infos = self.config.to_dict()
         if full_infos:
@@ -529,8 +513,10 @@ class NotebookController(SimulatorController):
                 # execute routines of the controller
                 self.controller_routine_step(self.time)
 
-                # execute routines of the entities
+                # execute routines of the existing entities
                 for entity in self.all_entities:
+                    if not entity.exists:
+                        continue
                     entity.routine_step(self.time)
                     entity.set_events()
                     # execute behaviors of agents
@@ -634,6 +620,23 @@ class NotebookController(SimulatorController):
         :return: box size
         """
         return self.configs[StateType.SIMULATOR][0].box_size
+
+    # TODO: Test this in notebooks
+    @property
+    def existing_agents(self):
+        """Return the list of existing agents
+
+        :return: existing agents
+        """
+        return [agent for agent in self.agents if agent.exists]
+
+    @property
+    def non_existing_agents(self):
+        """Return the list of non existing agents
+
+        :return: non existing agents
+        """
+        return [agent for agent in self.agents if not agent.exists]
 
 
 def spawn_entity_routine_fn(controller, entity_type=None, position_range=None):

--- a/vivarium/controllers/utils.py
+++ b/vivarium/controllers/utils.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 
 lg = logging.getLogger(__name__)
 
@@ -39,7 +40,6 @@ class Logger(object):
         self.logs = {}
 
 
-# TODO : add a lock to the detach behavior and to the behave function to prevent the simulator from crashing --> DO IT DIRECTLY HERE
 class RoutineHandler(object):
     """RoutineHandler class that handles routines for the NotebookController and its Entities
     """
@@ -47,8 +47,8 @@ class RoutineHandler(object):
         """Initialize the RoutineHandler
         """
         self._routines = {}
+        self._lock = threading.Lock()
 
-    # TODO : add start routines + start_all routines 
     def attach_routine(self, routine_fn, name=None, interval=1):
         """Attach a routine to the entity
 
@@ -57,41 +57,43 @@ class RoutineHandler(object):
         :param interval: routine execution interval, defaults to 1
         """
         assert isinstance(interval, int) and interval > 0, "Interval must be a positive integer"
-        self._routines[name or routine_fn.__name__] = (routine_fn, interval)
+        with self._lock:
+            self._routines[name or routine_fn.__name__] = (routine_fn, interval)
 
     def detach_routine(self, name):
         """Detach a routine from the entity
 
         :param name: routine name
         """
-        del self._routines[name]
+        with self._lock:
+            del self._routines[name]
 
-    # TODO : call the detach_routine function for all routines to make use of the lock
     def detach_all_routines(self):
         """Detach all routines from the entity
         """
         for name in list(self._routines.keys()):
             self.detach_routine(name)
 
-    # TODO : add a flag to prevent or allow automatic error catching in behavior execution
     def routine_step(self, entity, time, catch_errors=True):
         """Execute the entity's routines with their corresponding execution intervals, and remove the ones that cause errors
         """
         to_remove = []
-        # iterate over the routines and check if they work
-        for name, (fn, interval) in self._routines.items():
-            if time % interval == 0:
-                # if the catch_errors flag is set to True, catch the errors and remove the routine if it fails
-                if catch_errors:
-                    try:
-                        # execute the function on the entity object if the routine works
+        with self._lock:
+            # iterate over the routines and check if they work
+            for name, (fn, interval) in self._routines.items():
+                if time % interval == 0:
+                    # if the catch_errors flag is set to True, catch the errors and remove the routine if it fails
+                    if catch_errors:
+                        try:
+                            # execute the function on the entity object if the routine works
+                            fn(entity)
+                        except Exception as e:
+                            # else plot an error message and remove the routine
+                            lg.error(f"Error while executing routine: {e}, removing routine {name}")
+                            to_remove.append(name)
+                    # else just execute the routines normally
+                    else:
                         fn(entity)
-                    except Exception as e:
-                        # else plot an error message and remove the routine
-                        lg.error(f"Error while executing routine: {e}, removing routine {name}")
-                        to_remove.append(name)
-                else:
-                    fn(entity)
         
         # remove all problematic routines at the end to prevent spamming error messages and crashing the program
         if catch_errors:
@@ -101,4 +103,5 @@ class RoutineHandler(object):
     def print_routines(self):
         """Print the routines attached to the entity
         """
-        print(f"Attached routines: {list(self._routines.keys())}")
+        with self._lock:
+            print(f"Attached routines: {list(self._routines.keys())}")

--- a/vivarium/controllers/utils.py
+++ b/vivarium/controllers/utils.py
@@ -39,6 +39,7 @@ class Logger(object):
         self.logs = {}
 
 
+# TODO : add a lock to the detach behavior and to the behave function to prevent the simulator from crashing --> DO IT DIRECTLY HERE
 class RoutineHandler(object):
     """RoutineHandler class that handles routines for the NotebookController and its Entities
     """
@@ -47,6 +48,7 @@ class RoutineHandler(object):
         """
         self._routines = {}
 
+    # TODO : add start routines + start_all routines 
     def attach_routine(self, routine_fn, name=None, interval=1):
         """Attach a routine to the entity
 
@@ -64,29 +66,37 @@ class RoutineHandler(object):
         """
         del self._routines[name]
 
+    # TODO : call the detach_routine function for all routines to make use of the lock
     def detach_all_routines(self):
         """Detach all routines from the entity
         """
-        self._routines = {}
+        for name in list(self._routines.keys()):
+            self.detach_routine(name)
 
-    def routine_step(self, entity, time):
+    # TODO : add a flag to prevent or allow automatic error catching in behavior execution
+    def routine_step(self, entity, time, catch_errors=True):
         """Execute the entity's routines with their corresponding execution intervals, and remove the ones that cause errors
         """
         to_remove = []
         # iterate over the routines and check if they work
         for name, (fn, interval) in self._routines.items():
             if time % interval == 0:
-                try:
-                    # execute the function on the entity object if the routine works
+                # if the catch_errors flag is set to True, catch the errors and remove the routine if it fails
+                if catch_errors:
+                    try:
+                        # execute the function on the entity object if the routine works
+                        fn(entity)
+                    except Exception as e:
+                        # else plot an error message and remove the routine
+                        lg.error(f"Error while executing routine: {e}, removing routine {name}")
+                        to_remove.append(name)
+                else:
                     fn(entity)
-                except Exception as e:
-                    # else plot an error message and remove the routine
-                    lg.error(f"Error while executing routine: {e}, removing routine {name}")
-                    to_remove.append(name)
         
         # remove all problematic routines at the end to prevent spamming error messages and crashing the program
-        for name in to_remove:
-            del self._routines[name]
+        if catch_errors:
+            for name in to_remove:
+                del self._routines[name]
     
     def print_routines(self):
         """Print the routines attached to the entity


### PR DESCRIPTION
## Description
<!--- Provide a brief summary of the changes in this pull request -->

Improve notebook controller API on various points:

- Only execute routines / behaviors of existing entities in the controller `run`
- Add helper attributes to access existing / non-existing agents
- Add a `catch_error` flag to either automatically catch errors for routines or not (could be renamed debug_mode or something similar). You can launch it like that with the run function of the controller:

```python
controller.run(catch_errors=False) #default is set to True
```

- Add locking mechanism to routine handler to prevent modifying the routines while they are called (e.g removing a routine during a routine step, resulting in an error)

While updating the new eating function, I got this (old is the old eating routine function, new the one I did, and Clem the one you did): 

```python
import timeit

from functools import partial

num_iterations = 1000

new = timeit.timeit(new, number=num_iterations)
old = timeit.timeit(old, number=num_iterations)
clem = timeit.timeit(clem, number=num_iterations)

print(f"Old took {old:.6f} seconds")
print(f"New took {new:.6f} seconds")
print(f"Clem took {clem:.6f} seconds")
```

Session 5: 
```
Old took 0.806134 seconds
New took 1.754245 seconds
Clem took 1.760777 seconds
```

Session neuroevo_ABC:
```
Old took 0.043899 seconds
New took 0.124735 seconds
Clem took 0.116994 seconds
```

Seems like the old function works better, can you also try this on your computer ? 
