### PR TITLE
Seems to fix to the hide non-existing issue

### DIFF
--- a/vivarium/controllers/panel_controller.py
+++ b/vivarium/controllers/panel_controller.py
@@ -112,14 +112,6 @@ class PanelController(SimulatorController):
             selected.param.watch(
                 self.pull_selected_panel_configs, ["selection"], onlychanged=True
             )
-        # Add this to force non existing entities to be hidden at the initialization of the interface
-        threading.Timer(1.0, self.trigger_hide_non_existing).start()
-
-    def trigger_hide_non_existing(self):
-        """Triggers the hide_non_existing parameter change"""
-        self.panel_simulator_config.hide_non_existing = False
-        time.sleep(0.1)
-        self.panel_simulator_config.hide_non_existing = True
 
     def watch_selected_configs(self):
         """Watch the selected configurations"""

--- a/vivarium/interface/panel_app.py
+++ b/vivarium/interface/panel_app.py
@@ -43,7 +43,7 @@ class EntityManager:
         self.cds.on_change("data", self.drag_cb)
         self.cds_view = self.create_cds_view()
         self.panel_simulator_config.param.watch(
-            self.hide_all_non_existing, "hide_non_existing"
+            self.hide_all_non_existing, "hide_non_existing", onlychanged=False, 
         )
         selected.param.watch(
             self.update_selected_plot, ["selection"], onlychanged=True, precedence=0
@@ -51,7 +51,7 @@ class EntityManager:
         for i, pc in enumerate(self.panel_configs):
             pc.param.watch(self.update_cds_view, pc.param_names(), onlychanged=True)
             self.config[i].param.watch(
-                self.hide_non_existing, "exists", onlychanged=True
+                self.hide_non_existing, "exists", onlychanged=False
             )
 
     def drag_cb(self, attr, old, new):


### PR DESCRIPTION
## Description

@corentinlger This PR seems to fix to the hide non-existing issue #120 . In case you have time to have a quick look at it, can you tell me if you think it makes sense? (or more importantly, if you think it won't break anything else). Thanks :)
See "How to test" below.

## Related Issue (if applicable)

#120 

## How to Test

- Start practical session 4 
- Execute cells up to `controller.run()`
- Open the web interface
- Close the notebook session by executing the last cell of the session, but do **not** close the interface windows
- Restart the jupyter kernel and restart the session
- Execute cells up to `controller.run()`
- Refresh the interface windows. 
 
Before this fix, we were having a `RuntimeError: _pending_writes should be non-None when we have a document lock, and we should have the lock when the document changes' in the last executed notebook cell`. It shouldn't be the case now. 

Also check that we don't see hidden entities in the interface (if it works, you should see 7 resources).
